### PR TITLE
correct the class attributes name for mixed precision training

### DIFF
--- a/semilearn/core/algorithmbase.py
+++ b/semilearn/core/algorithmbase.py
@@ -51,7 +51,7 @@ class AlgorithmBase:
         self.num_iter_per_epoch = int(self.num_train_iter // self.epochs)
         self.lambda_u = args.ulb_loss_ratio 
         self.use_cat = args.use_cat
-        self.use_amp = args.use_amp
+        self.use_amp = args.amp
         self.clip_grad = args.clip_grad
         self.save_name = args.save_name
         self.save_dir = args.save_dir

--- a/train.py
+++ b/train.py
@@ -82,7 +82,7 @@ def get_config():
     ## core algorithm setting
     parser.add_argument('-alg', '--algorithm', type=str, default='fixmatch', help='ssl algorithm')
     parser.add_argument('--use_cat', type=str2bool, default=True, help='use cat operation in algorithms')
-    parser.add_argument('--use_amp', type=str2bool, default=False, help='use mixed precision training or not')
+    parser.add_argument('--amp', type=str2bool, default=False, help='use mixed precision training or not')
     parser.add_argument('--clip_grad', type=float, default=0)
 
     ## imbalance algorithm setting


### PR DESCRIPTION
## What does this PR do?

correct the variables/class attribute name for mixed precision training

in all the config files, the related hyperparameter is named 'amp', but use_amp is used while assigning values to class attributes, which needs to be fixed, otherwise, this hyperparameter in the config file will never be used and cannot control the mixed precision training stuff


