### PR TITLE
Remove entity interface.

### DIFF
--- a/semilearn/core/hooks/wandb.py
+++ b/semilearn/core/hooks/wandb.py
@@ -43,7 +43,6 @@ class WANDBHook(Hook):
                               tags=tags, 
                               config=algorithm.args.__dict__, 
                               project=project, 
-                              entity="usb",
                               resume=resume,
                               dir=save_dir)
 


### PR DESCRIPTION
To enable the Wandb logging. You should remove the entity interface.

Currently, it will return assess denied error.