### PR TITLE
Bump up torchaudio versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,7 @@ tifffile==2021.11.2
 timm==0.5.4
 tokenizers==0.12.1
 torch>=1.12.0
-torchaudio==0.12.0
+torchaudio>=0.12.0
 torchvision>=0.13.0
 tqdm==4.64.0
 transformers==4.20.1


### PR DESCRIPTION
Currently, requirements.txt requires torchaudio == 0.12, this version in turn requires torch == 0.12. Following the current installation guide for conda this leads to old cuda versions by default, and doesn't work for new graphics cards (e.g. A100s). 

If there is no specific reason for the strict torchaudio version I suggest allowing >=
