### PR TITLE
[fix] Rename "aimstack" to "aim" in the requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -61,4 +61,4 @@ Werkzeug==2.1.2
 zipp==3.8.0
 pynacl
 wandb
-aimstack
+aim


### PR DESCRIPTION
## What does this PR do?

The Aim package name on pypi is `aim`.
Thus it should have been listed as `aim` instead of `aimstack` in the `requirements.txt`.

### Does your PR introduce any breaking changes? If yes, please list them.

<!-- FILL IN or None -->

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you list all the **breaking changes** introduced by this pull request?

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
