### PR TITLE
[Fix] DARP wasn't applied when using ReMixMatch.

### DIFF
--- a/semilearn/algorithms/remixmatch/remixmatch.py
+++ b/semilearn/algorithms/remixmatch/remixmatch.py
@@ -133,10 +133,13 @@ class ReMixMatch(AlgorithmBase):
                 sharpen_prob_x_ulb = prob_x_ulb ** (1 / self.T)
                 sharpen_prob_x_ulb = (sharpen_prob_x_ulb / sharpen_prob_x_ulb.sum(dim=-1, keepdim=True)).detach()
 
-                if self.args.imb_algorithm == "darp":
+                # if pseudo labeling hook is registered, call it 
+                # this is implemented for imbalanced algorithm - DARP and DASO
+                if self.registered_hook("PseudoLabelingHook"):
                     sharpen_prob_x_ulb = self.call_hook("gen_ulb_targets", "PseudoLabelingHook", 
                                                         logits=sharpen_prob_x_ulb,
                                                         use_hard_label=False,
+                                                        T=self.T,
                                                         softmax=False)
 
             

--- a/semilearn/algorithms/remixmatch/remixmatch.py
+++ b/semilearn/algorithms/remixmatch/remixmatch.py
@@ -133,6 +133,12 @@ class ReMixMatch(AlgorithmBase):
                 sharpen_prob_x_ulb = prob_x_ulb ** (1 / self.T)
                 sharpen_prob_x_ulb = (sharpen_prob_x_ulb / sharpen_prob_x_ulb.sum(dim=-1, keepdim=True)).detach()
 
+                if self.args.imb_algorithm == "darp":
+                    sharpen_prob_x_ulb = self.call_hook("gen_ulb_targets", "PseudoLabelingHook", 
+                                                        logits=sharpen_prob_x_ulb,
+                                                        use_hard_label=False,
+                                                        softmax=False)
+
             
             self.bn_controller.freeze_bn(self.model)
             outs_x_lb = self.model(x_lb)


### PR DESCRIPTION
## What does this PR do?

Hi, I found the DARP method was not applied when using ReMixMatch as the base algorithm. The train_step() function in both the ReMixMatch and DARP classes did not reference the "PseudoLabelingHook". In order to address this issue, I made a modification to the ReMixMatch class so that it will check and apply DARP after the Distribution Alignment.

### Does your PR introduce any breaking changes? If yes, please list them.

The changes had an impact on the results of ReMixMatch + DARP, and did not have any effect on other configurations.

## Before submitting

- [ ] Was this **discussed/approved** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/lightning/blob/master/.github/CONTRIBUTING.md), **Pull Request** section?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you list all the **breaking changes** introduced by this pull request?

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

## PR review

Anyone in the community is welcome to review the PR.
Before you start reviewing, make sure you have read the [review guidelines](https://github.com/Lightning-AI/lightning/wiki/Review-guidelines). In short, see the following bullet-list:

- [x] Is this pull request ready for review? (if not, please submit in draft mode)
- [x] Check that all items from **Before submitting** are resolved
- [x] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified
